### PR TITLE
Don't lowercase _ENV or strings.

### DIFF
--- a/pico_on_save.py
+++ b/pico_on_save.py
@@ -3,9 +3,12 @@ import sublime_plugin
 
 class PicoToLower(sublime_plugin.TextCommand):
 	def run(self, edit):
-		upper = self.view.find_all("[A-Z]+")
+		upper = self.view.find_all("(_ENV)|([A-Z]+)")
 		for region in upper:
-			self.view.replace(edit, region, self.view.substr(region).lower())
+			s = self.view.substr(region)
+			if s == "_ENV" or self.view.score_selector(region.a, "string") > 0:
+				continue
+			self.view.replace(edit, region, s.lower())
 
 class PicoOnSave(sublime_plugin.EventListener):
 	def on_pre_save(self, view):


### PR DESCRIPTION
It looks like the original version of Sublime Pico-8 hasn't taken patches even though there have been some pretty substantial upgrades in the interim. I spent a good chunk of today improving the syntax highlighting (including coloring the sprite sheet), and then later found that you've already done it all much better than I did. oops! (Yours looks well-thought-out and is much more thorough; mine is just hacked together from the specific things I noticed and poring through the Sublime Text 3 docs today. My tinkering is at https://github.com/AdamNorberg/sublime-PICO-8/tree/pico8-0-2-25e if you're curious but I doubt there's much to see.) However, there's one other patch I wrote to make the plugin less annoying; if you're actively using this version of the plugin, this patch might be useful to you. Also, please consider this a nudge to fork completely and publish this as a separate package (Sublime Pico-8 Enhanced?) for the benefit of everyone who would like to use Sublime Text as their .p8 editor.

Anyway, this code change:

The special Lua table named _ENV is sometimes used in Pico-8 for various shenanigans. There are other special Lua tables with capitalized, case-sensitive names, but I don't know if any are widely used. But changing _ENV to _env inconvenienced me personally so I'm fixing that one. :)

Additionally, strings often deliberately contain uppercase characters, since they render as "puny font" in Pico-8. Lowercaseificaiton does more harm than good in a string context. If the syntax highlighting engine thinks we're in a string, do not tinker with case.